### PR TITLE
:construction_worker: Fix Wrong npm Version Target When Branch is Master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ node {
 
   def dockerfile_builds = [:];
 
-  def process_engine_version = branch_is_master ? 'master' : 'develop';
+  def process_engine_version = branch_is_master ? 'latest' : 'develop';
 
 
   NODE_VERSIONS.each {


### PR DESCRIPTION
**Changes**:

1. Use latest instead of master on master branch.


**Issues**:


PR: #4