### PR TITLE
:construction_worker: Require Docker Label For Builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ def create_dockerfile_build_step(node_version, process_engine_version) {
   }
 }
 
-node {
+node('docker') {
   checkout scm;
 
   def branch_is_master = BRANCH_NAME == 'master';


### PR DESCRIPTION
**Changes:**

1. Require a docker label for build agents of this job.


**Issues:**


PR: #5
