### PR TITLE
🔥 Remove global image pruning from cleanup step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,18 +1,5 @@
 #!/usr/bin/env groovy
 
-def cleanup_docker() {
-  // Build stages in dockerfiles leave dangling images behind (see https://github.com/moby/moby/issues/34151).
-  // Dangling images are images that are not used anywhere and don't have a tag. It is safe to remove them (see https://stackoverflow.com/a/45143234).
-  // This removes all dangling images
-  sh "docker image prune --force"
-
-  // Some Dockerfiles create volumes using the `VOLUME` command (see https://docs.docker.com/engine/reference/builder/#volume)
-  // running the speedtests creates two dangling volumes. One is from postgres (which contains data), but i don't know about the other one (which is empty)
-  // Dangling volumes are volumes that are not used anywhere. It is safe to remove them.
-  // This removes all dangling volumes
-  sh "docker volume prune --force"
-}
-
 def cleanup_workspace() {
   cleanWs()
   dir("${WORKSPACE}@tmp") {
@@ -109,13 +96,4 @@ node('docker') {
   parallel dockerfile_builds;
 
   cleanup_workspace();
-
-  // Ignore any failures during docker clean up.
-  // 'docker image prune --force' fails if
-  // two builds run simultaneously.
-  try {
-    cleanup_docker();
-  } catch (Exception error) {
-    echo "Failed to cleanup docker $error";
-  }
 }


### PR DESCRIPTION
**Changes:**

The cleanup step will no longer forcibly remove all images and volumes.
This has frequently caused problems with other Jenkins builds, who were no longer able to find required images, after another build had forcibly removed them.

Note that the `process_engine_runtime_docker_image` builds already clean up their own images (See [here](https://github.com/process-engine/process_engine_runtime_docker_image/blob/develop/Jenkinsfile#L87)) so there shouldn't be any leftovers.

PR: #6

## How can others test the changes?

Start the build and note that no images other than the builds own gets wiped afterwards.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).